### PR TITLE
[FIX] HTTP warning 로그 기준 상향

### DIFF
--- a/setMatchInfo/getMatchInfoByMatchId/app/src/main/java/job/match/info/Log.java
+++ b/setMatchInfo/getMatchInfoByMatchId/app/src/main/java/job/match/info/Log.java
@@ -38,7 +38,7 @@ public class Log {
     public void apiLog(long time, String uri) {
         if (time > 3000)
             failLog("HTTP 요청 성공 time: " + String.format("%7dms ", time) + " uri: " + uri);
-        else if (time > 1500)
+        else if (time > 2000)
             warningLog("HTTP 요청 성공 time: " + String.format("%7dms ", time) + " uri: " + uri);
         else
             successLog("HTTP 요청 성공 time: " + String.format("%7dms ", time) + " uri: " + uri);


### PR DESCRIPTION
warning 로그 2000ms 부터 출력하도록 기준 상향